### PR TITLE
Disable Metrics/BlockLength in specs

### DIFF
--- a/dev_tools/rubocop/infrastructure.yml
+++ b/dev_tools/rubocop/infrastructure.yml
@@ -3,6 +3,11 @@ inherit_from: base.yml
 Bundler/OrderedGems:
   Enabled: false
 
+Metrics/BlockLength:
+  ExcludedMethods:
+    - context
+    - describe
+
 Metrics/LineLength:
   Max: 120
 


### PR DESCRIPTION
Almost every spec file contains blocks longer than 25 lines.