### PR TITLE
Exclude factory-related methods from Metrics/BlockLength

### DIFF
--- a/dev_tools/rubocop/base.yml
+++ b/dev_tools/rubocop/base.yml
@@ -3,3 +3,4 @@ AllCops:
     - 'bin/{rails,rake}'
     - 'db/migrate/*'
     - 'db/schema.rb'
+    - 'node_modules/**/*'

--- a/dev_tools/rubocop/infrastructure.yml
+++ b/dev_tools/rubocop/infrastructure.yml
@@ -6,14 +6,18 @@ Bundler/OrderedGems:
 Metrics/BlockLength:
   ExcludedMethods:
     - context
+    - define
     - describe
+    - factory
 
 Metrics/LineLength:
   Max: 120
 
 Style/Documentation:
   Enabled: false
+
 Style/StringLiterals:
   EnforcedStyle: double_quotes
+
 Style/StringLiteralsInInterpolation:
   EnforcedStyle: double_quotes


### PR DESCRIPTION
This is just an extension of #4 and excludes factory-related methods from the block length cop.