### PR TITLE
Add RSpec/DescribeClass exclusions

### DIFF
--- a/dev_tools/rubocop/infrastructure.yml
+++ b/dev_tools/rubocop/infrastructure.yml
@@ -23,3 +23,12 @@ Style/StringLiterals:
 
 Style/StringLiteralsInInterpolation:
   EnforcedStyle: double_quotes
+
+# RSpec
+
+RSpec/DescribeClass:
+  Exclude:
+    - spec/features/**/*
+    - spec/integration/**/*
+    - spec/requests/**/*
+    - spec/routing/**/*


### PR DESCRIPTION
These specs typically use strings instead of classes/modules in their `describe` blocks.