### PR TITLE
[INFRA-1473] Update Rubocop config

### DIFF
--- a/dev_tools/rubocop/base.yml
+++ b/dev_tools/rubocop/base.yml
@@ -1,4 +1,6 @@
 AllCops:
+  NewCops: enable
+
   Exclude:
     - bin/{rails,rake}
     - db/migrate/*

--- a/dev_tools/rubocop/base.yml
+++ b/dev_tools/rubocop/base.yml
@@ -6,3 +6,4 @@ AllCops:
     - db/migrate/*
     - db/schema.rb
     - node_modules/**/*
+    - vendor/**/*

--- a/dev_tools/rubocop/infrastructure.yml
+++ b/dev_tools/rubocop/infrastructure.yml
@@ -1,5 +1,9 @@
 inherit_from: base.yml
 
+require:
+  - rubocop-performance
+  - rubocop-rspec
+
 Bundler/OrderedGems:
   Enabled: false
 

--- a/dev_tools/rubocop/infrastructure.yml
+++ b/dev_tools/rubocop/infrastructure.yml
@@ -16,7 +16,7 @@ Metrics/BlockLength:
     - shared_examples
     - shared_examples_for
 
-Metrics/LineLength:
+Layout/LineLength:
   Max: 120
 
 Style/Documentation:


### PR DESCRIPTION
Ticket: https://generalassembly.atlassian.net/browse/INFRA-1473

The other Infra apps are receiving ~2 years of Rubocop gem updates and this PR fixes some of the shared config.

Newer versions of Rubocop require new cops to be explicitly enabled or disabled unless enabled by default with `NewCops: enable`.

I also decided to include `rubocop-performance` and `rubocop-rspec` by default since they're relevant to all Infra apps.