### PR TITLE
Exclude config and spec directories from Metrics/BlockLength

### DIFF
--- a/dev_tools/rubocop/base.yml
+++ b/dev_tools/rubocop/base.yml
@@ -6,4 +6,10 @@ AllCops:
     - db/migrate/*
     - db/schema.rb
     - node_modules/**/*
+    - script/**/*
     - vendor/**/*
+
+Metrics/BlockLength:
+  Exclude:
+    - config/**/*
+    - spec/**/*

--- a/dev_tools/rubocop/infrastructure.yml
+++ b/dev_tools/rubocop/infrastructure.yml
@@ -7,15 +7,6 @@ require:
 Bundler/OrderedGems:
   Enabled: false
 
-Metrics/BlockLength:
-  ExcludedMethods:
-    - context
-    - define
-    - describe
-    - factory
-    - shared_examples
-    - shared_examples_for
-
 Layout/LineLength:
   Max: 120
 


### PR DESCRIPTION
I originally excluded specific spec methods from the `Metrics/BlockLength` cop but we should really just exclude the entire `config` and `spec` directories.

I moved the exclusion to the base config because it seems like a sensible default for all apps.