### PR TITLE
Add cop-diffs script

### DIFF
--- a/dev_tools/rubocop/cop-diffs
+++ b/dev_tools/rubocop/cop-diffs
@@ -1,0 +1,26 @@
+#!/usr/bin/env ruby
+
+# frozen_string_literal: true
+
+require "open3"
+
+DEFAULT_OPTIONS = %w[-P --only-recognized-file-types --force-exclusion].freeze
+
+PARALLEL_OPTIONS = %w[--parallel -P].freeze
+AUTO_CORRECT_OPTIONS = %w[--auto-correct -a].freeze
+
+DIFF_FILENAMES_CMD = "git diff master --name-only --diff-filter=AM"
+
+project_root, std_error = Open3.capture3("git rev-parse --show-toplevel")
+abort std_error unless std_error.empty?
+
+project_root.strip!
+abort "error: must be run from '#{project_root}'" unless Dir.pwd == project_root
+
+abort "error: no diffs found" if `#{DIFF_FILENAMES_CMD}`.empty?
+
+options = DEFAULT_OPTIONS + ARGV
+options -= PARALLEL_OPTIONS if (options & AUTO_CORRECT_OPTIONS).any?
+options = options.uniq.join(" ")
+
+system "bundle exec rubocop #{options} $(#{DIFF_FILENAMES_CMD})"


### PR DESCRIPTION
**note for people looking at this in the future:** `cop-diffs` is now located in a different directory

---

I wrote this a while ago but never shared it so here's the cleaned up version. I've been using it in most of my PRs.

This script will run Rubocop on the changed files in your branch. (compared to `master`)

You need to be in the root directory of a project to run it and all arguments are passed directly to Rubocop.

If you already have the [symlink](https://github.com/generalassembly/shared_configs#rubocop) set up then this script should be available in your other projects after pulling in the update.

examples:

```
# by default it runs on all compatible changed files
.rubocop/cop-diffs

# auto-correct
.rubocop/cop-diffs -a

# list cops by count
.rubocop/cop-diffs -fo

# list cops by count except RSpec/NestedGroups
.rubocop/cop-diffs -fo --except RSpec/NestedGroups

# list cops by count except all RSpec cops and Layout/LineLength
.rubocop/cop-diffs -fo --except RSpec,Layout/LineLength

# only use RSpec cops
.rubocop/cop-diffs --only RSpec
```

**note:** this directly compares against master so you won't always get the right results if master has also been updated since you branched off of it. You can fix this with a merge or rebase.