### PR TITLE
Fix Rails/UnknownEnv cop

### DIFF
--- a/dev_tools/rubocop/base.yml
+++ b/dev_tools/rubocop/base.yml
@@ -1,5 +1,6 @@
 inherit_mode:
   merge:
+    - Environments
     - Exclude
 
 require:

--- a/dev_tools/rubocop/infrastructure.yml
+++ b/dev_tools/rubocop/infrastructure.yml
@@ -1,9 +1,6 @@
 inherit_from:
   - base.yml
 
-Bundler/OrderedGems:
-  Enabled: false
-
 Layout/LineLength:
   Max: 120
 

--- a/dev_tools/rubocop/rails-base.yml
+++ b/dev_tools/rubocop/rails-base.yml
@@ -1,2 +1,9 @@
 require:
   - rubocop-rails
+
+Rails/UnknownEnv:
+  Environments:
+    - development
+    - production
+    - staging
+    - test

--- a/dev_tools/rubocop/rails-base.yml
+++ b/dev_tools/rubocop/rails-base.yml
@@ -1,9 +1,2 @@
 require:
   - rubocop-rails
-
-Rails/UnknownEnv:
-  Environments:
-    - development
-    - production
-    - staging
-    - test


### PR DESCRIPTION
The default config for [Rails/UnknownEnv](https://docs.rubocop.org/rubocop-rails/cops_rails.html#railsunknownenv) (development/production/test) is causing the rubocop parser to error out for other environment checks like `Rails.env.staging?`.

I set the inheritance mode to merge so that the apps can add other environments to `rubocop.yml` when needed.

I enabled [Bundler/OrderedGems](https://docs.rubocop.org/rubocop/cops_bundler.html#bundlerorderedgems) for Infra (enabled by default) since it only checks for gem ordering in groups separated by empty lines instead of the `Gemfile` as a whole.