### PR TITLE
Fix auto-correct options for cop-diffs script

### DIFF
--- a/dev_tools/rubocop/cop-diffs
+++ b/dev_tools/rubocop/cop-diffs
@@ -7,7 +7,7 @@ require "open3"
 DEFAULT_OPTIONS = %w[-P --only-recognized-file-types --force-exclusion].freeze
 
 PARALLEL_OPTIONS = %w[--parallel -P].freeze
-AUTO_CORRECT_OPTIONS = %w[--auto-correct -a].freeze
+AUTO_CORRECT_OPTIONS = %w[--auto-correct -a --auto-correct-all -A].freeze
 
 DIFF_FILENAMES_CMD = "git diff master --name-only --diff-filter=AM"
 


### PR DESCRIPTION
This PR updates the `cop-diffs` script so that it can be used with the `--auto-correct-all` and `-A` options.