### PR TITLE
Remove unnecessary Layout/LineLength config

### DIFF
--- a/dev_tools/rubocop/infrastructure.yml
+++ b/dev_tools/rubocop/infrastructure.yml
@@ -1,9 +1,6 @@
 inherit_from:
   - base.yml
 
-Layout/LineLength:
-  Max: 120
-
 Style/Documentation:
   Enabled: false
 


### PR DESCRIPTION
The default max line length was set to 120 in [Rubocop 0.84](https://github.com/rubocop-hq/rubocop/releases/tag/v0.84.0) which was released in May 2020.