### PR TITLE
Add "Semaphore current workflow" script

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ A collection of shared configuration files.
 
 ### Scripts
 
-You can call either these scripts directly or add this repository's `scripts`
+You can either call these scripts directly or add this repository's `scripts`
 directory to your `PATH` to easily access them from anywhere.
 
 * [cop-diffs](/dev_tools/scripts/cop-diffs): runs Rubocop on the changed files in your branch

--- a/README.md
+++ b/README.md
@@ -14,6 +14,9 @@ A collection of shared configuration files.
 You can call either these scripts directly or add this repository's `scripts`
 directory to your `PATH` to easily access them from anywhere.
 
+* [cop-diffs](/dev_tools/scripts/cop-diffs): runs Rubocop on the changed files in your branch
+* [scw](/dev_tools/scripts/scw): opens the current Semaphore workflow for your branch
+
 ### Rubocop
 
 If this repository is located in `~/code/shared_configs` and you're in the

--- a/README.md
+++ b/README.md
@@ -6,7 +6,13 @@ A collection of shared configuration files.
 
 ## Contents
 
+* [Scripts](#scripts)
 * [Rubocop](#rubocop)
+
+### Scripts
+
+You can call either these scripts directly or add this repository's `scripts`
+directory to your `PATH` to easily access them from anywhere.
 
 ### Rubocop
 

--- a/dev_tools/scripts/cop-diffs
+++ b/dev_tools/scripts/cop-diffs
@@ -2,25 +2,25 @@
 
 # frozen_string_literal: true
 
-require "open3"
+require 'open3'
 
 DEFAULT_OPTIONS = %w[-P --only-recognized-file-types --force-exclusion].freeze
 
 PARALLEL_OPTIONS = %w[--parallel -P].freeze
 AUTO_CORRECT_OPTIONS = %w[--auto-correct -a --auto-correct-all -A].freeze
 
-DIFF_FILENAMES_CMD = "git diff master --name-only --diff-filter=AM"
+DIFF_FILENAMES_CMD = 'git diff master --name-only --diff-filter=AM'
 
-project_root, std_error = Open3.capture3("git rev-parse --show-toplevel")
+project_root, std_error = Open3.capture3('git rev-parse --show-toplevel')
 abort std_error unless std_error.empty?
 
 project_root.strip!
 abort "error: must be run from '#{project_root}'" unless Dir.pwd == project_root
 
-abort "error: no diffs found" if `#{DIFF_FILENAMES_CMD}`.empty?
+abort 'error: no diffs found' if `#{DIFF_FILENAMES_CMD}`.empty?
 
 options = DEFAULT_OPTIONS + ARGV
 options -= PARALLEL_OPTIONS if (options & AUTO_CORRECT_OPTIONS).any?
-options = options.uniq.join(" ")
+options = options.uniq.join(' ')
 
 system "bundle exec rubocop #{options} $(#{DIFF_FILENAMES_CMD})"

--- a/dev_tools/scripts/scw
+++ b/dev_tools/scripts/scw
@@ -1,0 +1,28 @@
+#!/usr/bin/env ruby
+
+# frozen_string_literal: true
+
+if `command -v sem`.empty?
+  abort <<~ERROR
+    sem CLI not found
+
+    brew install semaphoreci/tap/sem
+
+    docs: https://docs.semaphoreci.com/reference/sem-command-line-tool/
+  ERROR
+end
+
+branch = `git branch --show-current`.strip
+
+workflows = `sem get workflows`.split("\n")
+
+begin
+  workflow_row = workflows.find { |workflow| workflow.match?(branch) }
+  workflow_id = workflow_row.split.first
+rescue NoMethodError
+  abort 'workflow not found'
+end
+
+workflow_url = "https://generalassembly.semaphoreci.com/workflows/#{workflow_id}"
+
+system "open #{workflow_url}"

--- a/dev_tools/scripts/scw
+++ b/dev_tools/scripts/scw
@@ -14,7 +14,7 @@ end
 
 branch = `git branch --show-current`.strip
 
-workflows = `sem get workflows`.split("\n")
+workflows = `sem get workflows`.lines
 
 begin
   workflow_row = workflows.find { |workflow| workflow.match?(branch) }
@@ -25,4 +25,4 @@ end
 
 workflow_url = "https://generalassembly.semaphoreci.com/workflows/#{workflow_id}"
 
-system "open #{workflow_url}"
+system 'open', workflow_url


### PR DESCRIPTION
This PR adds a script that opens the most recent Semaphore workflow for the current branch of a project.

Prepend or append this new scripts directory to your `PATH` and you can call `scw` in your projects.