### PR TITLE
Add CountAsOne config to various length metrics

### DIFF
--- a/dev_tools/rubocop/base.yml
+++ b/dev_tools/rubocop/base.yml
@@ -1,5 +1,6 @@
 inherit_mode:
   merge:
+    - CountAsOne
     - Environments
     - Exclude
 
@@ -22,3 +23,25 @@ Metrics/BlockLength:
   Exclude:
     - config/**/*
     - spec/**/*
+  CountAsOne:
+    - array
+    - hash
+    - heredoc
+
+Metrics/ClassLength:
+  CountAsOne:
+    - array
+    - hash
+    - heredoc
+
+Metrics/MethodLength:
+  CountAsOne:
+    - array
+    - hash
+    - heredoc
+
+Metrics/ModuleLength:
+  CountAsOne:
+    - array
+    - hash
+    - heredoc


### PR DESCRIPTION
This PR reduces the number of `Metrics/*Length` offenses by always counting arrays, hashes, and heredocs as single lines.

`bundle exec rubocop -fo --only Metrics/BlockLength,Metrics/ClassLength,Metrics/MethodLength,Metrics/ModuleLength`

Core (before)
```
22  Metrics/BlockLength
18  Metrics/MethodLength
14  Metrics/ClassLength
9   Metrics/ModuleLength
--
63  Total
```

Core (after)
```
14  Metrics/BlockLength
11  Metrics/ClassLength
6   Metrics/ModuleLength
5   Metrics/MethodLength
--
36  Total
```

Churchkey (before)
```
54  Metrics/MethodLength
9   Metrics/ClassLength
5   Metrics/BlockLength
--
68  Total
```

Churchkey (after)
```
31  Metrics/MethodLength
4   Metrics/ClassLength
2   Metrics/BlockLength
--
37  Total
```