### PR TITLE
Move rspec-base from team rails-level config to team-level config

### DIFF
--- a/dev_tools/rubocop/edtech-rails.yml
+++ b/dev_tools/rubocop/edtech-rails.yml
@@ -1,4 +1,3 @@
 inherit_from:
   - rails-base.yml
-  - rspec-base.yml
   - edtech.yml

--- a/dev_tools/rubocop/edtech.yml
+++ b/dev_tools/rubocop/edtech.yml
@@ -1,2 +1,3 @@
 inherit_from:
   - base.yml
+  - rspec-base.yml

--- a/dev_tools/rubocop/infrastructure-rails.yml
+++ b/dev_tools/rubocop/infrastructure-rails.yml
@@ -1,4 +1,3 @@
 inherit_from:
   - rails-base.yml
-  - rspec-base.yml
   - infrastructure.yml

--- a/dev_tools/rubocop/infrastructure.yml
+++ b/dev_tools/rubocop/infrastructure.yml
@@ -1,5 +1,6 @@
 inherit_from:
   - base.yml
+  - rspec-base.yml
 
 Style/Documentation:
   Enabled: false

--- a/dev_tools/rubocop/martech-rails.yml
+++ b/dev_tools/rubocop/martech-rails.yml
@@ -1,4 +1,3 @@
 inherit_from:
   - rails-base.yml
-  - rspec-base.yml
   - martech.yml

--- a/dev_tools/rubocop/martech.yml
+++ b/dev_tools/rubocop/martech.yml
@@ -1,2 +1,3 @@
 inherit_from:
   - base.yml
+  - rspec-base.yml


### PR DESCRIPTION
This lets us require rspec in the non-rails projects by simply inheriting from the appropriate team's config.