### PR TITLE
Exclude all locations for node modules

### DIFF
--- a/dev_tools/rubocop/base.yml
+++ b/dev_tools/rubocop/base.yml
@@ -17,7 +17,6 @@ AllCops:
     - db/schema.rb
     - "**/node_modules/**/*"
     - script/**/*
-    - vendor/**/*
 
 Metrics/BlockLength:
   Exclude:

--- a/dev_tools/rubocop/base.yml
+++ b/dev_tools/rubocop/base.yml
@@ -15,7 +15,7 @@ AllCops:
     - bin/{rails,rake}
     - db/migrate/*
     - db/schema.rb
-    - node_modules/**/*
+    - "**/node_modules/**/*"
     - script/**/*
     - vendor/**/*
 


### PR DESCRIPTION
Sometimes `node_nodules` is a subdirectory like `client/node_modules`.