### PR TITLE
[INFRA-4377] Add shared Brakeman config for Semaphore

### DIFF
--- a/PULL_REQUEST_TEMPLATE.md
+++ b/PULL_REQUEST_TEMPLATE.md
@@ -1,7 +1,1 @@
-**Ticket:** https://generalassembly.atlassian.net/browse/<ticket number>
-
-`REPLACE WITH OVERVIEW`
-
-**Documentation tasks**
-
-* [ ] README updated
+**Ticket:** https://generalassembly.atlassian.net/browse/TICKET

--- a/semaphore/.semaphore/bin/run-brakeman
+++ b/semaphore/.semaphore/bin/run-brakeman
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+
+bundle exec brakeman \
+  --run-all-checks \
+  -o /dev/stdout --color \
+  -o $BRAKEMAN_REPORT_HTML

--- a/semaphore/.semaphore/bin/store-brakeman-report
+++ b/semaphore/.semaphore/bin/store-brakeman-report
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+
+if [[ $SEMAPHORE_GIT_BRANCH =~ ^(master|main)$ ]]; then
+  ARTIFACT_LEVEL=project
+else
+  ARTIFACT_LEVEL=workflow
+fi
+
+artifact push $ARTIFACT_LEVEL $BRAKEMAN_REPORT_HTML -f

--- a/semaphore/README.md
+++ b/semaphore/README.md
@@ -16,32 +16,14 @@ Some of these files need to exist at the time of Semaphore's `checkout` which is
 
 ## Setup
 
-Each repo needs a `setup-shared-config` Semaphore script:
+Each repo needs a [.semaphore/bin/setup-shared-config](templates/bin/setup-shared-config) Semaphore script:
 
 ``` bash
 touch .semaphore/bin/setup-shared-config
 chmod +x .semaphore/bin/*
 ```
 
-Contents of [.semaphore/bin/setup-shared-config](templates/bin/setup-shared-config):
-
-``` bash
-#!/usr/bin/env -S bash -e
-
-# see this repo for all available shared config:
-# https://github.com/generalassembly/shared_configs/tree/master/semaphore
-
-SHARED_CONFIG_REPO=https://github.com/generalassembly/shared_configs
-REMOTE_SHARED_CONFIG_DIR=$SHARED_CONFIG_REPO/trunk/semaphore/.semaphore
-LOCAL_SHARED_CONFIG_DIR=.semaphore-shared
-
-svn export $REMOTE_SHARED_CONFIG_DIR $LOCAL_SHARED_CONFIG_DIR
-
-cp --recursive --no-clobber $LOCAL_SHARED_CONFIG_DIR/. .semaphore/
-
-```
-
-Call `setup-shared-config` inside the repo's `.semaphore/bin/setup-repo` script:
+Call `setup-shared-config` inside the repo's `.semaphore/bin/setup-repo` script by inserting it after the `SEMAPHORE_BIN_DIR` export:
 
 ``` bash
 #!/usr/bin/env -S bash -e
@@ -50,7 +32,7 @@ export PROJECT_DIR=$PWD
 export SEMAPHORE_DIR=$PROJECT_DIR/.semaphore
 export SEMAPHORE_BIN_DIR=$SEMAPHORE_DIR/bin
 
-$SEMAPHORE_BIN_DIR/setup-shared-config # insert this line after the SEMAPHORE_BIN_DIR export above
+$SEMAPHORE_BIN_DIR/setup-shared-config
 
 export PATH=./bin:$PATH:$SEMAPHORE_BIN_DIR
 ```

--- a/semaphore/templates/bin/setup-shared-config
+++ b/semaphore/templates/bin/setup-shared-config
@@ -7,6 +7,10 @@ SHARED_CONFIG_REPO=https://github.com/generalassembly/shared_configs
 REMOTE_SHARED_CONFIG_DIR=$SHARED_CONFIG_REPO/trunk/semaphore/.semaphore
 LOCAL_SHARED_CONFIG_DIR=.semaphore-shared
 
+# NOTE: you can test a custom branch of shared_configs
+# uncomment the line below and replace xyz with the name of your branch
+# REMOTE_SHARED_CONFIG_DIR=$SHARED_CONFIG_REPO/branches/xyz/semaphore/.semaphore
+
 svn export $REMOTE_SHARED_CONFIG_DIR $LOCAL_SHARED_CONFIG_DIR
 
 cp --recursive --no-clobber $LOCAL_SHARED_CONFIG_DIR/. .semaphore/

--- a/semaphore/templates/brakeman.yml
+++ b/semaphore/templates/brakeman.yml
@@ -1,0 +1,40 @@
+version: v1.0
+
+name: brakeman
+
+agent:
+  machine:
+    type: e1-standard-2
+    os_image: ubuntu2004
+
+auto_cancel:
+  running:
+    when: "true"
+
+global_job_config:
+  secrets:
+    - name: global-secrets
+
+  env_vars:
+    - name: BRAKEMAN_REPORT_HTML
+      value: brakeman.html
+
+  prologue:
+    commands:
+      - checkout
+      - source .semaphore/bin/setup-repo
+
+blocks:
+  - name: Brakeman Report
+    task:
+      jobs:
+        - name: brakeman
+          commands:
+            - restore-gems
+
+            - run-brakeman
+
+      epilogue:
+        always:
+          commands:
+            - store-brakeman-report


### PR DESCRIPTION
**Ticket:** https://generalassembly.atlassian.net/browse/INFRA-4377

This PR:
* allows apps to remove these scripts:
  * `.semaphore/bin/run-brakeman`
  * `.semaphore/bin/store-brakeman-report`
* provides a sample `brakeman.yml` pipeline that can be manually copied to other apps

Also the two scripts mentioned above can be edited in this repo and the changes are automatically propagated to all apps that have already set up shared Semaphore config.

If an app needs to overwrite a shared script then it can add a custom script with the same name/location to its repo.